### PR TITLE
Batch D: namespaced duplicated updater (v1.6149.0734)

### DIFF
--- a/github-updater.php
+++ b/github-updater.php
@@ -1,259 +1,263 @@
 <?php
 /**
- * Shared GitHub release updater.
+ * Bundled GitHub release updater.
  *
- * @package TIMU_GitHub_Updater
+ * Polls a GitHub Release for a newer tag and feeds it into WordPress's
+ * plugin-update transient. Duplicated per-plugin under a plugin-unique
+ * namespace so two co-installed plugins can't collide.
+ *
+ * @package ThisIsMyURL\ImageSupport
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
+namespace ThisIsMyURL\ImageSupport;
 
-if ( ! class_exists( 'TIMU_GitHub_Release_Updater' ) ) {
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Register update checks against GitHub releases.
+ */
+class GitHubReleaseUpdater {
+
 	/**
-	 * Register update checks against GitHub releases.
+	 * Plugin file path.
+	 *
+	 * @var string
 	 */
-	class TIMU_GitHub_Release_Updater {
-		/**
-		 * Plugin file path.
-		 *
-		 * @var string
-		 */
-		private $plugin_file;
+	private $plugin_file;
 
-		/**
-		 * Plugin basename.
-		 *
-		 * @var string
-		 */
-		private $plugin_basename;
+	/**
+	 * Plugin basename.
+	 *
+	 * @var string
+	 */
+	private $plugin_basename;
 
-		/**
-		 * Plugin slug.
-		 *
-		 * @var string
-		 */
-		private $slug;
+	/**
+	 * Plugin slug.
+	 *
+	 * @var string
+	 */
+	private $slug;
 
-		/**
-		 * GitHub repository owner/name.
-		 *
-		 * @var string
-		 */
-		private $repo;
+	/**
+	 * GitHub repository owner/name.
+	 *
+	 * @var string
+	 */
+	private $repo;
 
-		/**
-		 * Create updater instance.
-		 *
-		 * @param array<string, string> $config Updater config.
-		 */
-		public function __construct( $config ) {
-			$this->plugin_file     = (string) ( $config['plugin_file'] ?? '' );
-			$this->plugin_basename = plugin_basename( $this->plugin_file );
-			$this->slug            = sanitize_key( (string) ( $config['slug'] ?? '' ) );
-			$this->repo            = trim( (string) ( $config['repo'] ?? '' ) );
+	/**
+	 * Create updater instance.
+	 *
+	 * @param array<string, string> $config Updater config (plugin_file, slug, repo).
+	 */
+	public function __construct( $config ) {
+		$this->plugin_file     = (string) ( $config['plugin_file'] ?? '' );
+		$this->plugin_basename = \plugin_basename( $this->plugin_file );
+		$this->slug            = \sanitize_key( (string) ( $config['slug'] ?? '' ) );
+		$this->repo            = trim( (string) ( $config['repo'] ?? '' ) );
 
-			if ( '' === $this->plugin_file || '' === $this->slug || '' === $this->repo ) {
-				return;
-			}
-
-			add_filter( 'pre_set_site_transient_update_plugins', array( $this, 'check_for_updates' ) );
-			add_filter( 'plugins_api', array( $this, 'plugin_info' ), 10, 3 );
-			add_filter( 'upgrader_post_install', array( $this, 'after_install' ), 10, 3 );
+		if ( '' === $this->plugin_file || '' === $this->slug || '' === $this->repo ) {
+			return;
 		}
 
-		/**
-		 * Normalize Git tag versions for version_compare.
-		 *
-		 * @param string $version Raw version.
-		 * @return string
-		 */
-		private function normalize_version( $version ) {
-			$version = trim( (string) $version );
-			$version = ltrim( $version, "vV \t\n\r\0\x0B" );
+		\add_filter( 'pre_set_site_transient_update_plugins', array( $this, 'check_for_updates' ) );
+		\add_filter( 'plugins_api', array( $this, 'plugin_info' ), 10, 3 );
+		\add_filter( 'upgrader_post_install', array( $this, 'after_install' ), 10, 3 );
+	}
 
-			return $version;
+	/**
+	 * Normalize Git tag versions for version_compare.
+	 *
+	 * @param string $version Raw version.
+	 * @return string
+	 */
+	private function normalize_version( $version ) {
+		$version = trim( (string) $version );
+		$version = ltrim( $version, "vV \t\n\r\0\x0B" );
+
+		return $version;
+	}
+
+	/**
+	 * Return release metadata from GitHub API.
+	 *
+	 * @return array<string, string>|false
+	 */
+	private function get_release_data() {
+		$cache_key = 'timu_gh_release_' . md5( $this->repo );
+		$cached    = \get_site_transient( $cache_key );
+		if ( is_array( $cached ) && ! empty( $cached['version'] ) && ! empty( $cached['zipball_url'] ) ) {
+			return $cached;
 		}
 
-		/**
-		 * Return release metadata from GitHub API.
-		 *
-		 * @return array<string, string>|false
-		 */
-		private function get_release_data() {
-			$cache_key = 'timu_gh_release_' . md5( $this->repo );
-			$cached    = get_site_transient( $cache_key );
-			if ( is_array( $cached ) && ! empty( $cached['version'] ) && ! empty( $cached['zipball_url'] ) ) {
-				return $cached;
-			}
+		$api_url  = 'https://api.github.com/repos/' . $this->repo . '/releases/latest';
+		$response = \wp_remote_get(
+			$api_url,
+			array(
+				'timeout' => 15,
+				'headers' => array(
+					'Accept'     => 'application/vnd.github+json',
+					'User-Agent' => 'WordPress/' . \get_bloginfo( 'version' ) . '; ' . \home_url( '/' ),
+				),
+			)
+		);
 
-			$api_url  = 'https://api.github.com/repos/' . $this->repo . '/releases/latest';
-			$response = wp_remote_get(
-				$api_url,
-				array(
-					'timeout' => 15,
-					'headers' => array(
-						'Accept'     => 'application/vnd.github+json',
-						'User-Agent' => 'WordPress/' . get_bloginfo( 'version' ) . '; ' . home_url( '/' ),
-					),
-				)
-			);
-
-			if ( is_wp_error( $response ) ) {
-				return false;
-			}
-
-			$status_code = (int) wp_remote_retrieve_response_code( $response );
-			if ( 200 !== $status_code ) {
-				return false;
-			}
-
-			$body    = json_decode( (string) wp_remote_retrieve_body( $response ), true );
-			$tag     = isset( $body['tag_name'] ) ? $this->normalize_version( (string) $body['tag_name'] ) : '';
-			$zip_url = isset( $body['zipball_url'] ) ? (string) $body['zipball_url'] : '';
-
-			if ( '' === $tag || '' === $zip_url ) {
-				return false;
-			}
-
-			$release = array(
-				'version'      => $tag,
-				'zipball_url'  => $zip_url,
-				'html_url'     => isset( $body['html_url'] ) ? (string) $body['html_url'] : 'https://github.com/' . $this->repo,
-				'published_at' => isset( $body['published_at'] ) ? (string) $body['published_at'] : '',
-				'body'         => isset( $body['body'] ) ? (string) $body['body'] : '',
-			);
-
-			set_site_transient( $cache_key, $release, 6 * HOUR_IN_SECONDS );
-
-			return $release;
+		if ( \is_wp_error( $response ) ) {
+			return false;
 		}
 
-		/**
-		 * Inject update metadata into core update transient.
-		 *
-		 * @param object $transient Update transient.
-		 * @return object
-		 */
-		public function check_for_updates( $transient ) {
-			if ( ! is_object( $transient ) || empty( $transient->checked ) || ! is_array( $transient->checked ) ) {
-				return $transient;
-			}
+		$status_code = (int) \wp_remote_retrieve_response_code( $response );
+		if ( 200 !== $status_code ) {
+			return false;
+		}
 
-			$current_version = isset( $transient->checked[ $this->plugin_basename ] ) ? $this->normalize_version( (string) $transient->checked[ $this->plugin_basename ] ) : '';
-			if ( '' === $current_version ) {
-				return $transient;
-			}
+		$body    = json_decode( (string) \wp_remote_retrieve_body( $response ), true );
+		$tag     = isset( $body['tag_name'] ) ? $this->normalize_version( (string) $body['tag_name'] ) : '';
+		$zip_url = isset( $body['zipball_url'] ) ? (string) $body['zipball_url'] : '';
 
-			$release = $this->get_release_data();
-			if ( ! is_array( $release ) ) {
-				return $transient;
-			}
+		if ( '' === $tag || '' === $zip_url ) {
+			return false;
+		}
 
-			if ( version_compare( $release['version'], $current_version, '>' ) ) {
-				$update              = new stdClass();
-				$update->slug        = $this->slug;
-				$update->plugin      = $this->plugin_basename;
-				$update->new_version = $release['version'];
-				$update->url         = $release['html_url'];
-				$update->package     = $release['zipball_url'];
+		$release = array(
+			'version'      => $tag,
+			'zipball_url'  => $zip_url,
+			'html_url'     => isset( $body['html_url'] ) ? (string) $body['html_url'] : 'https://github.com/' . $this->repo,
+			'published_at' => isset( $body['published_at'] ) ? (string) $body['published_at'] : '',
+			'body'         => isset( $body['body'] ) ? (string) $body['body'] : '',
+		);
 
-				$transient->response[ $this->plugin_basename ] = $update;
-			}
+		\set_site_transient( $cache_key, $release, 6 * \HOUR_IN_SECONDS );
 
+		return $release;
+	}
+
+	/**
+	 * Inject update metadata into core update transient.
+	 *
+	 * @param object $transient Update transient.
+	 * @return object
+	 */
+	public function check_for_updates( $transient ) {
+		if ( ! is_object( $transient ) || empty( $transient->checked ) || ! is_array( $transient->checked ) ) {
 			return $transient;
 		}
 
-		/**
-		 * Render plugin information popup.
-		 *
-		 * @param false|object|array<string, mixed> $result Existing result.
-		 * @param string                             $action Action type.
-		 * @param object                             $args   Request args.
-		 * @return false|object|array<string, mixed>
-		 */
-		public function plugin_info( $result, $action, $args ) {
-			if ( 'plugin_information' !== $action || ! isset( $args->slug ) || $this->slug !== $args->slug ) {
-				return $result;
-			}
-
-			$release = $this->get_release_data();
-			if ( ! is_array( $release ) ) {
-				return $result;
-			}
-
-			$info              = new stdClass();
-			$info->name        = ucfirst( str_replace( '-', ' ', $this->slug ) );
-			$info->slug        = $this->slug;
-			$info->version     = $release['version'];
-			$info->author      = '<a href="https://github.com/' . esc_attr( strtok( $this->repo, '/' ) ) . '">' . esc_html( strtok( $this->repo, '/' ) ) . '</a>';
-			$info->homepage    = $release['html_url'];
-			$info->download_link = $release['zipball_url'];
-			$info->last_updated  = $release['published_at'];
-			$info->sections      = array(
-				'description' => wp_kses_post( wpautop( $release['body'] ) ),
-				'changelog'   => wp_kses_post( wpautop( $release['body'] ) ),
-			);
-
-			return $info;
+		$current_version = isset( $transient->checked[ $this->plugin_basename ] ) ? $this->normalize_version( (string) $transient->checked[ $this->plugin_basename ] ) : '';
+		if ( '' === $current_version ) {
+			return $transient;
 		}
 
-		/**
-		 * Keep installed folder stable after GitHub zip extraction.
-		 *
-		 * @param array<string, mixed> $response   Installer response.
-		 * @param array<string, mixed> $hook_extra Extra context.
-		 * @param array<string, mixed> $result     Install result.
-		 * @return array<string, mixed>
-		 */
-		public function after_install( $response, $hook_extra, $result ) {
-			if ( empty( $hook_extra['plugin'] ) || $this->plugin_basename !== $hook_extra['plugin'] ) {
-				return $result;
-			}
+		$release = $this->get_release_data();
+		if ( ! is_array( $release ) ) {
+			return $transient;
+		}
 
-			global $wp_filesystem;
-			if ( ! $wp_filesystem || empty( $result['destination'] ) ) {
-				return $result;
-			}
+		if ( version_compare( $release['version'], $current_version, '>' ) ) {
+			$update              = new \stdClass();
+			$update->slug        = $this->slug;
+			$update->plugin      = $this->plugin_basename;
+			$update->new_version = $release['version'];
+			$update->url         = $release['html_url'];
+			$update->package     = $release['zipball_url'];
 
-			$install_directory = plugin_dir_path( $this->plugin_file );
-			if ( $wp_filesystem->exists( $install_directory ) ) {
-				$wp_filesystem->delete( $install_directory, true );
-			}
+			$transient->response[ $this->plugin_basename ] = $update;
+		}
 
-			if ( $wp_filesystem->move( $result['destination'], $install_directory, true ) ) {
-				$result['destination'] = $install_directory;
-			}
+		return $transient;
+	}
 
-			if ( ! function_exists( 'is_plugin_active' ) ) {
-				require_once ABSPATH . 'wp-admin/includes/plugin.php';
-			}
-
-			if ( function_exists( 'is_plugin_active' ) && is_plugin_active( $this->plugin_basename ) ) {
-				activate_plugin( $this->plugin_basename );
-			}
-
+	/**
+	 * Render plugin information popup.
+	 *
+	 * @param false|object|array<string, mixed> $result Existing result.
+	 * @param string                            $action Action type.
+	 * @param object                            $args   Request args.
+	 * @return false|object|array<string, mixed>
+	 */
+	public function plugin_info( $result, $action, $args ) {
+		if ( 'plugin_information' !== $action || ! isset( $args->slug ) || $this->slug !== $args->slug ) {
 			return $result;
 		}
-	}
-}
 
-if ( ! function_exists( 'timu_boot_github_release_updater' ) ) {
+		$release = $this->get_release_data();
+		if ( ! is_array( $release ) ) {
+			return $result;
+		}
+
+		$info                = new \stdClass();
+		$info->name          = ucfirst( str_replace( '-', ' ', $this->slug ) );
+		$info->slug          = $this->slug;
+		$info->version       = $release['version'];
+		$info->author        = '<a href="https://github.com/' . \esc_attr( strtok( $this->repo, '/' ) ) . '">' . \esc_html( strtok( $this->repo, '/' ) ) . '</a>';
+		$info->homepage      = $release['html_url'];
+		$info->download_link = $release['zipball_url'];
+		$info->last_updated  = $release['published_at'];
+		$info->sections      = array(
+			'description' => \wp_kses_post( \wpautop( $release['body'] ) ),
+			'changelog'   => \wp_kses_post( \wpautop( $release['body'] ) ),
+		);
+
+		return $info;
+	}
+
 	/**
-	 * Bootstrap shared GitHub updater for a plugin.
+	 * Keep installed folder stable after GitHub zip extraction.
 	 *
-	 * @param array<string, string> $config Updater config.
+	 * @param array<string, mixed> $response   Installer response.
+	 * @param array<string, mixed> $hook_extra Extra context.
+	 * @param array<string, mixed> $result     Install result.
+	 * @return array<string, mixed>
+	 */
+	public function after_install( $response, $hook_extra, $result ) {
+		if ( empty( $hook_extra['plugin'] ) || $this->plugin_basename !== $hook_extra['plugin'] ) {
+			return $result;
+		}
+
+		global $wp_filesystem;
+		if ( ! $wp_filesystem || empty( $result['destination'] ) ) {
+			return $result;
+		}
+
+		$install_directory = \plugin_dir_path( $this->plugin_file );
+		if ( $wp_filesystem->exists( $install_directory ) ) {
+			$wp_filesystem->delete( $install_directory, true );
+		}
+
+		if ( $wp_filesystem->move( $result['destination'], $install_directory, true ) ) {
+			$result['destination'] = $install_directory;
+		}
+
+		if ( ! function_exists( 'is_plugin_active' ) ) {
+			require_once \ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
+		if ( function_exists( 'is_plugin_active' ) && \is_plugin_active( $this->plugin_basename ) ) {
+			\activate_plugin( $this->plugin_basename );
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Bootstrap a single updater instance per plugin basename.
+	 *
+	 * Idempotent per plugin_file so a double-include can't register the
+	 * filters twice.
+	 *
+	 * @param array<string, string> $config Updater config (plugin_file, slug, repo).
 	 * @return void
 	 */
-	function timu_boot_github_release_updater( $config ) {
+	public static function boot( $config ) {
 		static $instances = array();
 
 		$plugin_file = isset( $config['plugin_file'] ) ? (string) $config['plugin_file'] : '';
-		$key         = plugin_basename( $plugin_file );
+		$key         = \plugin_basename( $plugin_file );
 		if ( '' === $key || isset( $instances[ $key ] ) ) {
 			return;
 		}
 
-		$instances[ $key ] = new TIMU_GitHub_Release_Updater( $config );
+		$instances[ $key ] = new self( $config );
 	}
 }

--- a/github-updater.php
+++ b/github-updater.php
@@ -1,10 +1,10 @@
 <?php
 /**
- * Bundled GitHub release updater.
+ * Shared GitHub release updater.
  *
  * Polls a GitHub Release for a newer tag and feeds it into WordPress's
- * plugin-update transient. Duplicated per-plugin under a plugin-unique
- * namespace so two co-installed plugins can't collide.
+ * plugin-update transient. Bundled per-plugin under a prefixed namespace so
+ * two co-installed plugins can't collide on the class name.
  *
  * @package ThisIsMyURL\ImageSupport
  */
@@ -243,8 +243,8 @@ class GitHubReleaseUpdater {
 	/**
 	 * Bootstrap a single updater instance per plugin basename.
 	 *
-	 * Idempotent per plugin_file so a double-include can't register the
-	 * filters twice.
+	 * Idempotent per plugin_file so a double-include can't register the filters
+	 * twice.
 	 *
 	 * @param array<string, string> $config Updater config (plugin_file, slug, repo).
 	 * @return void

--- a/readme.txt
+++ b/readme.txt
@@ -8,7 +8,7 @@ Tags: webp, media, images, optimization, filenames, photo credits, attribution, 
 Requires at least: 6.4
 Tested up to: 7.0
 Requires PHP: 8.1
-Stable tag: 1.6148.2110
+Stable tag: 1.6149.0734
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/thisismyurl-image-support.php
+++ b/thisismyurl-image-support.php
@@ -3,7 +3,7 @@
  * Plugin Name: This Is My URL - Image Support
  * Plugin URI:  https://thisismyurl.com/thisismyurl-image-support/
  * Description: Image filename cleanup, duplicate merging, WebP discovery, photo-credit attribution, and alt-text accessibility fallback. The cleanup/merge features are destructive and require opt-in via the "Confirm destructive operations" option before any rename, merge, or post_content rewrite runs; the photo-credit and alt-fallback features are benign and never touch files or post content.
- * Version:     1.6148.2110
+ * Version:     1.6149.0734
  * Requires at least: 6.4
  * Requires PHP: 8.1
  * Author:      Christopher Ross
@@ -27,7 +27,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * for asset enqueuing and cache-busting. Kept in sync with the `Version:`
  * header above by the release process.
  */
-define( 'TIMU_IMAGE_SUPPORT_VERSION', '1.6148.2110' );
+define( 'TIMU_IMAGE_SUPPORT_VERSION', '1.6149.0734' );
 define( 'TIMU_IMAGE_SUPPORT_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TIMU_IMAGE_SUPPORT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/thisismyurl-image-support.php
+++ b/thisismyurl-image-support.php
@@ -1674,7 +1674,7 @@ add_action(
 
 require_once plugin_dir_path( __FILE__ ) . 'github-updater.php';
 
-timu_boot_github_release_updater(
+\ThisIsMyURL\ImageSupport\GitHubReleaseUpdater::boot(
     array(
         'plugin_file' => __FILE__,
         'slug'        => 'thisismyurl-image-support',


### PR DESCRIPTION
Batch D: shared GitHub updater bundled as per-plugin namespaced duplicated code (no separate repo, no build tooling).

- github-updater.php = hardened updater under namespace ThisIsMyURL\<Short>, byte-identical across the line except the namespace line.
- Old per-plugin updater (TIMU_GitHub_(Release_)?Updater) removed; svg/revision-reaper/login upgraded to the hardened version.
- Runtime-verified class+boot; php -l clean. Version 1.6149.0734.