### PR TITLE
Plugin name prefix and wp_unslash on POST read

### DIFF
--- a/thisismyurl-image-support.php
+++ b/thisismyurl-image-support.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Plugin Name: - Image Support by Christopher Ross
+ * Plugin Name: Image Support by Christopher Ross
  * Plugin URI:  https://thisismyurl.com/thisismyurl-image-support/
  * Description: Image filename cleanup, duplicate merging, WebP discovery, photo-credit attribution, and alt-text accessibility fallback. The cleanup/merge features are destructive and require opt-in via the "Confirm destructive operations" option before any rename, merge, or post_content rewrite runs; the photo-credit and alt-fallback features are benign and never touch files or post content.
  * Version:     1.6149.0734
@@ -1578,7 +1578,7 @@ class TIMU_IC {
 
         // Batch is capped at 50 to match handle_cleanup()'s internal clamp; the previous 1000 was theatre.
         $user_batch = $is_post && isset( $_POST['batch_limit'] )
-            ? max( 1, min( 50, (int) $_POST['batch_limit'] ) )
+            ? max( 1, min( 50, (int) wp_unslash( $_POST['batch_limit'] ) ) )
             : 5;
 
         $confirmed = (bool) get_option( 'thisismyurl_image_support_confirm_destructive', false );


### PR DESCRIPTION
## Summary

Two Plugin Check findings: leading dash in plugin name, missing wp_unslash() on $_POST['batch_limit'].

## Changes

Plugin Check (PHPCS) fixes — no behaviour changes to production functionality.

## Test plan

- [ ] Install on a WordPress test site and confirm plugin activates without errors
- [ ] Verify Plugin Check passes with no new warnings on the modified files
- [ ] Confirm existing functionality unchanged

_AI-assisted: fixes researched and applied with Claude Sonnet 4.6; reviewed by Christopher Ross._